### PR TITLE
Remove createPlankPermissions call in secureMode

### DIFF
--- a/pkg/squashctl/app.go
+++ b/pkg/squashctl/app.go
@@ -193,10 +193,6 @@ func (o *Options) runBaseCommandWithRbac() error {
 		return err
 	}
 
-	if err := o.createPlankPermissions(); err != nil {
-		return err
-	}
-
 	if err := o.writeDebugAttachment(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Removing the call to createPlankPermissions() to remain consistent with the understanding that Kubernetes resources should not be altered or deploy when running in secureMode.